### PR TITLE
fix(api): require auth on /api/upload-auth

### DIFF
--- a/src/app/api/upload-auth/route.ts
+++ b/src/app/api/upload-auth/route.ts
@@ -1,21 +1,23 @@
 import { getUploadAuthParams } from "@imagekit/next/server"
+import { auth } from "@/auth"
 
 export async function GET() {
+  const session = await auth()
+  if (!session?.user) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 })
+  }
+
   try {
-    // Add authentication logic here if needed
-    // For example, check if user is logged in or has upload permissions
-    
     const { token, expire, signature } = getUploadAuthParams({
       privateKey: process.env.IMAGEKIT_PRIVATE_KEY as string,
       publicKey: process.env.NEXT_PUBLIC_IMAGEKIT_PUBLIC_KEY as string,
-      // expire: 30 * 60, // Optional: 30 minutes expiry, max 1 hour
     });
 
-    return Response.json({ 
-      token, 
-      expire, 
-      signature, 
-      publicKey: process.env.NEXT_PUBLIC_IMAGEKIT_PUBLIC_KEY 
+    return Response.json({
+      token,
+      expire,
+      signature,
+      publicKey: process.env.NEXT_PUBLIC_IMAGEKIT_PUBLIC_KEY,
     });
   } catch (error) {
     console.error('Upload auth error:', error);


### PR DESCRIPTION
## Summary
- `/api/upload-auth` was an unauthenticated `GET` returning ImageKit upload credentials to anyone — a credential-leak vector against our ImageKit quota.
- Adds `auth()` guard, returns `401` on no session, no other behavior change.
- The single caller (`src/components/ui/file-upload.tsx`) already throws on non-OK responses, so the unauth path surfaces as a UI error rather than a crash.

## Changes
- `src/app/api/upload-auth/route.ts` — import `auth` from `@/auth`, return 401 when no session

## Test plan
- [ ] \`curl -i http://localhost:3000/api/upload-auth\` → 401 when not signed in
- [ ] Sign in, hit endpoint via \`<FileUpload>\` component → token/signature returned, upload succeeds
- [ ] Verify no regression on existing authenticated upload flow

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)