### PR TITLE
fix(auth): redact PII from sign-in logs and gate debug to dev

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -45,7 +45,6 @@ export const {
   },
   events: {
     async linkAccount({ user }) {
-      console.log("OAuth account linked:", user.email);
       if (user.id) {
         await db.user.update({
           where: { id: user.id },
@@ -53,24 +52,9 @@ export const {
         })
       }
     },
-    async signIn({ user, account, isNewUser }) {
-      console.log("Sign-in event:", { 
-        userId: user.id, 
-        email: user.email,
-        provider: account?.provider,
-        isNewUser
-      });
-    }
   },
   callbacks: {
     async signIn({ user, account }) {
-      // Log sign-in attempt for debugging
-      console.log("Sign-in attempt:", { 
-        userId: user.id, 
-        provider: account?.provider,
-        email: user.email
-      });
-      
       if (!user.id) return false
       
       if (account?.provider !== "credentials") return true
@@ -129,7 +113,6 @@ export const {
   },
   adapter: PrismaAdapter(db),
   session: { strategy: "jwt" },
-  // Enable debug mode temporarily to get detailed error information
-  debug: true, // Set to true for both dev and production to debug
+  debug: process.env.NODE_ENV !== "production",
   ...authConfig,
 })


### PR DESCRIPTION
## Summary
- NextAuth callbacks logged \`userId\`/\`email\`/\`provider\` on every sign-in/link → PII in plaintext Vercel logs.
- \`debug: true\` was hardcoded on (commented "Set to true for both dev and production").
- Drops the three \`console.log\` blocks; switches \`debug\` to dev-only.
- Auth flow logic is unchanged — only logging and debug flag.

## Changes
- \`src/auth.ts\` — removed \`events.signIn\` handler entirely (only purpose was logging), removed log lines from \`events.linkAccount\` and \`callbacks.signIn\`, gated \`debug\` to non-production.

## Test plan
- [ ] Sign in via credentials → success on /en and /ar
- [ ] Sign in via Google OAuth → success
- [ ] Tail \`vercel logs\` during sign-in → no email/userId in output
- [ ] Trigger an auth error → still surfaces (debug works in dev only)

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)