### PR TITLE
fix(config): whitelist ik.imagekit.io in remotePatterns

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -30,6 +30,12 @@ const nextConfig: NextConfig = {
         port: '',
         pathname: '/**',
       },
+      {
+        protocol: 'https',
+        hostname: 'ik.imagekit.io',
+        port: '',
+        pathname: '/**',
+      },
     ],
   },
 };


### PR DESCRIPTION
## Summary
- Adds \`ik.imagekit.io\` to \`next.config.ts\` \`images.remotePatterns\`.
- Unblocks the OptimizedImage migration (PR-12 in the remediation plan); without this, any \`next/image\` pointing at \`https://ik.imagekit.io/*\` returns 400.

## Changes
- \`next.config.ts\` — appended ImageKit entry to \`images.remotePatterns\`

## Test plan
- [ ] Render an \`<Image src=\"https://ik.imagekit.io/databayt/...\" />\` → no \"Invalid src\" warning, image loads
- [ ] Existing pravatar/unsplash/website-files/githubusercontent URLs still work

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)