### PR TITLE
fix(404): locale-aware not-found page

### DIFF
--- a/src/app/[lang]/not-found.tsx
+++ b/src/app/[lang]/not-found.tsx
@@ -1,12 +1,20 @@
 import Link from 'next/link';
+import { cookies } from 'next/headers';
 import { Button } from '@/components/ui/button';
 import { getDictionary } from '@/components/internationalization/dictionaries';
-import type { Locale } from '@/components/internationalization/config';
+import { i18n, type Locale } from '@/components/internationalization/config';
+
+async function resolveLocale(): Promise<Locale> {
+  const store = await cookies();
+  const cookieLocale = store.get('NEXT_LOCALE')?.value;
+  return (i18n.locales as readonly string[]).includes(cookieLocale ?? '')
+    ? (cookieLocale as Locale)
+    : i18n.defaultLocale;
+}
 
 export default async function NotFound() {
-  // For not-found pages, we can't reliably get locale from params
-  // so we'll default to English and handle this gracefully
-  const dict = await getDictionary('en');
+  const locale = await resolveLocale();
+  const dict = await getDictionary(locale);
 
   return (
     <div className="flex min-h-screen flex-col items-center justify-center">
@@ -16,7 +24,7 @@ export default async function NotFound() {
           <h2 className="text-2xl font-bold">{dict.errors.notFound}</h2>
         </div>
         <Button asChild>
-          <Link href="/en">
+          <Link href={`/${locale}`}>
             {dict.common.home}
           </Link>
         </Button>


### PR DESCRIPTION
## Summary
- 404 page hardcoded English dict + \`/en\` home link → Arabic users sent to wrong locale.
- Reads \`NEXT_LOCALE\` cookie set by \`proxy.ts\`, validates against \`i18n.locales\`, falls back to default.
- Both \`errors.notFound\` and \`common.home\` keys already exist in \`ar.json\` — no dictionary changes.

## Changes
- \`src/app/[lang]/not-found.tsx\` — added \`resolveLocale\` helper, dynamic locale + href

## Test plan
- [ ] Visit \`/ar/this-does-not-exist\` → Arabic 404, button text \`الرئيسية\`, link to \`/ar\`
- [ ] Visit \`/en/this-does-not-exist\` → English 404, button \`Home\`, link to \`/en\`
- [ ] Clear cookies, hit a non-existent root path → falls back to default locale

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)