### PR TITLE
fix(auth): restore SessionProvider in [lang]/layout

### DIFF
--- a/src/app/[lang]/layout.tsx
+++ b/src/app/[lang]/layout.tsx
@@ -9,8 +9,8 @@ import { ImageKitProvider } from "@/components/ui/imagekit-provider";
 import { Toaster } from "sonner";
 import { getDictionary } from "@/components/internationalization/dictionaries";
 import { type Locale, localeConfig } from "@/components/internationalization/config";
-// import { SessionProvider } from "next-auth/react";
-// import { auth } from "@/auth";
+import { SessionProvider } from "next-auth/react";
+import { auth } from "@/auth";
 
 // Configure Rubik font for Arabic
 const rubik = Rubik({
@@ -80,11 +80,10 @@ export default async function LocaleLayout({
   children: React.ReactNode;
   params: Promise<{ lang: Locale }>;
 }>) {
-  // const session = await auth();
-  const { lang } = await params;
+  const [{ lang }, session] = await Promise.all([params, auth()]);
   const config = localeConfig[lang];
   const isRTL = config.dir === 'rtl';
-  
+
   return (
     <html lang={lang} dir={config.dir}>
       <body
@@ -95,19 +94,16 @@ export default async function LocaleLayout({
           rubik.variable
         )}
       >
-        {/* <SessionProvider session={session}> */}
-         
-            <ThemeProvider>
-              <ImageKitProvider>
-                <div className="layout-container">
-                  <Toaster position={isRTL ? "bottom-left" : "bottom-right"} />
-                  
-                  {children}
-                </div>
-              </ImageKitProvider>
-            </ThemeProvider>
-          
-        {/* </SessionProvider> */}
+        <SessionProvider session={session}>
+          <ThemeProvider>
+            <ImageKitProvider>
+              <div className="layout-container">
+                <Toaster position={isRTL ? "bottom-left" : "bottom-right"} />
+                {children}
+              </div>
+            </ImageKitProvider>
+          </ThemeProvider>
+        </SessionProvider>
       </body>
     </html>
   );


### PR DESCRIPTION
## Summary
- \`SessionProvider\` and the \`auth()\` call were commented out in the locale layout → every client \`useSession()\` returned \`unauthenticated\`, breaking 6 components (\`useCurrentUser\`, \`useCurrentRole\`, \`<RoleGate>\`, header avatar, pricing role form, delete-account modal).
- Restores the wrapper. Calls \`auth()\` and \`params\` in parallel via \`Promise.all\` to avoid sequencing the two awaits.
- Leaves \`pages: { signIn: \"/login\" }\` as-is — \`proxy.ts\` already locale-prefixes redirects on the next request, so static \`/login\` becomes \`/{locale}/login\` by cookie/Accept-Language match.

## Changes
- \`src/app/[lang]/layout.tsx\` — uncommented \`SessionProvider\` + \`auth\` import; wrapped children; parallel awaits.

## Test plan
- [ ] Sign in via credentials on \`/en/login\` → header avatar shows the user
- [ ] Sign in via Google OAuth on \`/ar/login\` → redirected to \`/ar\`, avatar shows
- [ ] \`<RoleGate allowedRole=\"USER\">\` renders for signed-in user
- [ ] \`useCurrentUser()\` returns the user object in pricing modals
- [ ] \`pnpm build\` succeeds

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)