### PR TITLE
chore(ts): mechanical strict-mode prep fixes (Class 4)

### DIFF
--- a/prisma.config.ts
+++ b/prisma.config.ts
@@ -2,6 +2,5 @@ import 'dotenv/config'
 import { defineConfig } from 'prisma/config'
 
 export default defineConfig({
-  earlyAccess: true,
   schema: './prisma/schema.prisma',
 })

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,7 +1,7 @@
 import { MetadataRoute } from 'next';
-import { type Locale, i18n } from '@/components/internationalization/config';
+import { i18n } from '@/components/internationalization/config';
 
-const locales: Locale[] = i18n.locales;
+const locales = i18n.locales;
 const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || 'http://localhost:3001';
 
 // Define all your pages here

--- a/src/components/chatbot/chat-button.tsx
+++ b/src/components/chatbot/chat-button.tsx
@@ -14,8 +14,8 @@ export function ChatButton({
   dictionary 
 }: ChatButtonProps) {
   const [shouldInvert, setShouldInvert] = useState(false);
-  const checkTimeoutRef = useRef<NodeJS.Timeout>();
-  const rafRef = useRef<number>();
+  const checkTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const rafRef = useRef<number | null>(null);
 
   useEffect(() => {
     const checkSections = () => {

--- a/src/components/marketing/pricing/sections/features.tsx
+++ b/src/components/marketing/pricing/sections/features.tsx
@@ -20,7 +20,8 @@ export default function Features() {
 
           <div className="mt-12 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
             {features.map((feature) => {
-              const Icon = Icons[feature.icon || "nextjs"];
+              const iconKey = (feature.icon || "nextjs") as keyof typeof Icons;
+              const Icon = Icons[iconKey];
               return (
                 <div
                   className="group relative overflow-hidden rounded-2xl border bg-background p-5 md:p-8"

--- a/src/components/ui/language-switcher.tsx
+++ b/src/components/ui/language-switcher.tsx
@@ -28,14 +28,14 @@ export function LanguageSwitcher() {
     router.push(href);
   };
 
-  const currentLanguage = localeConfig[locale as Locale];
+  const currentLanguage = localeConfig[locale];
 
   return (
     <Select value={locale} onValueChange={handleLanguageChange}>
       <SelectTrigger className="w-auto min-w-[120px] gap-2">
         <Languages className="h-4 w-4" />
         <SelectValue>
-          {currentLanguage?.nativeName || currentLanguage?.name}
+          {currentLanguage?.nativeName}
         </SelectValue>
       </SelectTrigger>
       <SelectContent>

--- a/src/components/ui/optimized-image.tsx
+++ b/src/components/ui/optimized-image.tsx
@@ -15,6 +15,7 @@ interface OptimizedImageProps extends ComponentProps<'img'> {
   priority?: boolean;
   placeholder?: 'blur' | 'empty';
   blurDataURL?: string;
+  quality?: number;
 }
 
 export function OptimizedImage({

--- a/src/components/wizard/branding/actions.ts
+++ b/src/components/wizard/branding/actions.ts
@@ -28,7 +28,7 @@ export async function updateBranding(
     if (error instanceof z.ZodError) {
       return {
         success: false,
-        error: error.errors[0]?.message || "Validation failed",
+        error: error.issues[0]?.message || "Validation failed",
       };
     }
 


### PR DESCRIPTION
## Summary
- 7 isolated TS errors surfaced by the \`ignoreBuildErrors\` audit (36 errors / 28 files / 5 classes total).
- This PR covers **Class 4** — mechanical fixes that need no product or schema decisions. Verified locally: \`tsc --noEmit\` shows zero errors for the 7 files touched here.

## Changes (per file)
- \`prisma.config.ts\` — drop \`earlyAccess: true\` (removed in Prisma 7 GA)
- \`src/app/sitemap.ts\` — drop the redundant \`Locale[]\` mutable annotation
- \`src/components/chatbot/chat-button.tsx\` — initialize \`useRef\` with \`null\`
- \`src/components/marketing/pricing/sections/features.tsx\` — cast icon key
- \`src/components/ui/language-switcher.tsx\` — drop unreachable \`|| .name\` fallback (literal narrowing)
- \`src/components/ui/optimized-image.tsx\` — add \`quality?: number\` to props type
- \`src/components/wizard/branding/actions.ts\` — \`error.errors\` → \`error.issues\` for Zod 4

## Test plan
- [ ] \`pnpm tsc --noEmit\` clean for the 7 touched files
- [ ] LanguageSwitcher still shows correct native name on /en and /ar
- [ ] Pricing features section renders with the right icons
- [ ] Chatbot button still responds to scroll-debounce inversion
- [ ] Wizard branding form surfaces a validation error message on bad input

## Follow-ups
Remaining classes (in separate PRs):
- **Class 3** (dict drift, 6 errors) — next PR
- **Class 5** (Next 16 \`LayoutProps\`, 1 error) — after PR #10 (SessionProvider) merges to avoid conflict
- **Class 2** (\`User.username\` schema drift, 8 errors) — needs your decision: restore field or refactor to \`name\`?
- **Class 1** (12 dead imports from clone artifacts) — needs per-feature decisions

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)