### PR TITLE
fix(ts): dictionary type drift (Class 3)

### DIFF
--- a/src/components/example/internationalized-content.tsx
+++ b/src/components/example/internationalized-content.tsx
@@ -15,10 +15,10 @@ export function InternationalizedContent() {
       </p>
       <div className={`flex gap-2 ${isRTL ? 'flex-row-reverse' : 'flex-row'}`}>
         <button className="bg-primary text-primary-foreground px-4 py-2 rounded">
-          {t.marketing.hero.cta}
+          {t.marketing.hero.appointment}
         </button>
         <button className="border border-border px-4 py-2 rounded">
-          {t.marketing.hero.learnMore}
+          {t.marketing.hero.services}
         </button>
       </div>
       

--- a/src/components/marketing/content.tsx
+++ b/src/components/marketing/content.tsx
@@ -102,10 +102,10 @@ export default function SiteContent({ dictionary, params }: SiteContentProps) {
         </div>
       </section>
       <section className="py-10">
-        <FeatureCards dictionary={dictionary.marketing.featureCards} params={params} />
+        <FeatureCards />
       </section>
       <section className="py-10">
-        <Parallax dictionary={dictionary.marketing.parallax} params={params} />
+        <Parallax />
       </section>
       <section className="py-10">
         <Ready dictionary={dictionary.marketing.ready} params={params} />
@@ -114,10 +114,10 @@ export default function SiteContent({ dictionary, params }: SiteContentProps) {
         <OpenSource />
       </section>
       <section className="py-10">
-        <Stack dictionary={dictionary.marketing.stack} params={params} />
+        <Stack />
       </section>
       <section className="pt-10">
-        <ReadyToBuildSection dictionary={dictionary.marketing.readyToBuild} params={params} />
+        <ReadyToBuildSection />
       </section>
     </div>
   );


### PR DESCRIPTION
## Summary
- 6 TS errors from stale dict references + prop drilling to prop-less components.
- Verified \`tsc --noEmit\` clean for the 2 touched files.
- Builds on top of Class 4 work (#12). Independent — does not depend on it.

## Changes
- \`src/components/example/internationalized-content.tsx\` — map \`hero.cta\`/\`hero.learnMore\` to existing keys (\`appointment\`/\`services\`). Demo file, never imported elsewhere.
- \`src/components/marketing/content.tsx\` — drop unused \`dictionary\`/\`params\` props from \`<FeatureCards>\`, \`<Parallax>\`, \`<Stack>\`, \`<ReadyToBuildSection>\`. Each of these reads i18n via \`useTranslations()\` directly.

## Test plan
- [ ] /en and /ar marketing landing render all sections (FeatureCards, Parallax, Ready, Stack, ReadyToBuildSection)
- [ ] No console warnings about unknown props

## Follow-ups
Remaining classes:
- Class 5 (LayoutProps) — after #10 merges
- Class 2 (\`User.username\` schema drift, 8 errors) — needs your decision: restore \`username\` field or migrate code to \`name\`?
- Class 1 (12 dead imports from \`@/components/platform/\`, \`@/components/onboarding/\`, \`@/components/invoice/\`, \`@/components/atom/modal\`, \`@react-email/components\`) — needs per-feature decisions

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)