### PR TITLE
fix(ts): rename User.username → User.name (schema drift)

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -119,7 +119,7 @@ export const {
       const existingAccount = await getAccountByUserId(existingUser.id)
 
       token.isOAuth = !!existingAccount
-      token.name = existingUser.username
+      token.name = existingUser.name
       token.email = existingUser.email
       token.role = existingUser.role
       token.isTwoFactorEnabled = existingUser.isTwoFactorEnabled

--- a/src/components/marketing/pricing/actions/update-user-name.ts
+++ b/src/components/marketing/pricing/actions/update-user-name.ts
@@ -25,7 +25,7 @@ export async function updateUserName(userId: string, data: FormData) {
         id: userId,
       },
       data: {
-        username: name,
+        name: name,
       },
     })
 

--- a/src/components/marketing/pricing/forms/user-name.action.ts
+++ b/src/components/marketing/pricing/forms/user-name.action.ts
@@ -12,7 +12,7 @@ export async function updateUserName(userId: string, data: FormData) {
   if (!parsed.success) {
     return { status: "error" as const };
   }
-  await db.user.update({ where: { id: userId }, data: { username: parsed.data.name } });
+  await db.user.update({ where: { id: userId }, data: { name: parsed.data.name } });
   revalidatePath("/dashboard/settings");
   return { status: "success" as const };
 }

--- a/src/components/marketing/pricing/lib/email.ts
+++ b/src/components/marketing/pricing/lib/email.ts
@@ -28,7 +28,7 @@ export const sendVerificationRequest: EmailConfig["sendVerificationRequest"] =
             : identifier,
         subject: authSubject,
         react: MagicLinkEmail({
-          firstName: (user.username ?? "") as string,
+          firstName: (user.name ?? "") as string,
           actionUrl: url,
           mailType: userVerified ? "login" : "register",
           siteName: siteConfig.name,

--- a/src/components/marketing/pricing/lib/user.ts
+++ b/src/components/marketing/pricing/lib/user.ts
@@ -7,7 +7,7 @@ export const getUserByEmail = async (email: string) => {
         email: email,
       },
       select: {
-        username: true,
+        name: true,
         emailVerified: true,
       },
     });

--- a/src/components/marketing/pricing/modals/delete-account-modal.tsx
+++ b/src/components/marketing/pricing/modals/delete-account-modal.tsx
@@ -49,7 +49,7 @@ function DeleteAccountModal({
       <div className="flex flex-col items-center justify-center space-y-3 border-b p-4 pt-8 sm:px-16">
         <UserAvatar
           user={{
-            username: (session?.user as any)?.username ?? session?.user?.name ?? null,
+            name: session?.user?.name ?? null,
             image: session?.user?.image || null,
           }}
         />

--- a/src/components/marketing/pricing/shared/user-avatar.tsx
+++ b/src/components/marketing/pricing/shared/user-avatar.tsx
@@ -5,7 +5,7 @@ import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
 import { Icons } from "@/components/marketing/pricing/shared/icons"
 
 interface UserAvatarProps extends AvatarProps {
-  user: Pick<User, "image" | "username">
+  user: Pick<User, "image" | "name">
 }
 
 export function UserAvatar({ user, ...props }: UserAvatarProps) {
@@ -15,7 +15,7 @@ export function UserAvatar({ user, ...props }: UserAvatarProps) {
         <AvatarImage alt="Picture" src={user.image} referrerPolicy="no-referrer" />
       ) : (
         <AvatarFallback>
-          <span className="sr-only">{user.username ?? ""}</span>
+          <span className="sr-only">{user.name ?? ""}</span>
           <Icons.user className="size-4" />
         </AvatarFallback>
       )}


### PR DESCRIPTION
## Summary
- Schema is canonical: \`User.name\` exists, \`User.username\` does not. 7 call sites referenced the removed field, silently masked by \`ignoreBuildErrors\`.
- **Real bug uncovered**: \`src/auth.ts:122\` did \`token.name = existingUser.username\` — this evaluates to \`undefined\` at runtime, so every JWT shipped \`name: undefined\`. Every signed-in user has had \`session.user.name === undefined\` until this lands. After merge, header avatars / dropdowns / modals that display \`user.name\` will populate correctly.
- Mechanical rename, no schema migration needed.

## Changes
- \`src/auth.ts\` — JWT enrichment fix
- \`src/components/marketing/pricing/forms/user-name.action.ts\`
- \`src/components/marketing/pricing/actions/update-user-name.ts\`
- \`src/components/marketing/pricing/lib/user.ts\`
- \`src/components/marketing/pricing/lib/email.ts\`
- \`src/components/marketing/pricing/shared/user-avatar.tsx\`
- \`src/components/marketing/pricing/modals/delete-account-modal.tsx\` (UserAvatar caller — cascade)

## Test plan
- [ ] Sign in → header avatar shows the user's name (was previously empty/email-fallback)
- [ ] Settings → \"Your Name\" form persists to DB and re-renders updated name
- [ ] \`pnpm tsc --noEmit\` → 7 fewer errors (36 → 29 verified locally)
- [ ] Magic-link email path still types-correctly (firstName uses \`user.name\`)

## Follow-ups
- **Class 1** dead imports remain (12 errors — \`@/components/platform/*\`, \`@/components/onboarding/*\`, \`@/components/invoice/*\`, \`@/components/atom/modal\`, \`@react-email/components\`, \`db.subscriptionTier\`) — needs your decision per feature
- **Class 5** \`LayoutProps\` (1 error) — pending after #10 merges

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)