### PR TITLE
feat(i18n): locale-aware date + currency formatting

### DIFF
--- a/src/components/marketing/pricing/lib/utils.ts
+++ b/src/components/marketing/pricing/lib/utils.ts
@@ -69,9 +69,9 @@ export function constructMetadata({
   };
 }
 
-export function formatDate(input: string | number): string {
+export function formatDate(input: string | number, locale: string = 'en'): string {
   const date = new Date(input);
-  return date.toLocaleDateString("en-US", {
+  return date.toLocaleDateString(locale, {
     month: "long",
     day: "numeric",
     year: "numeric",

--- a/src/components/marketing/utils.ts
+++ b/src/components/marketing/utils.ts
@@ -5,13 +5,18 @@ export function getCurrentDomain(): string {
   return '';
 }
 
-export function formatDate(date: Date | string): string {
+export function formatDate(date: Date | string, locale: string = 'en'): string {
   const d = new Date(date);
-  return d.toLocaleDateString('en-US', {
+  return d.toLocaleDateString(locale, {
     year: 'numeric',
     month: 'long',
     day: 'numeric'
   });
+}
+
+export function formatCurrency(amount: number, locale: string = 'en'): string {
+  const currency = locale === 'ar' ? 'SAR' : 'USD';
+  return new Intl.NumberFormat(locale, { style: 'currency', currency }).format(amount);
 }
 
 export function truncateText(text: string, maxLength: number): string {


### PR DESCRIPTION
## Summary
- Replaces hardcoded \`'en-US'\` in two \`formatDate\` utilities with an optional \`locale\` parameter (default \`'en'\`).
- Adds \`formatCurrency(amount, locale)\` to \`marketing/utils.ts\` using \`Intl.NumberFormat\`. Maps locale to currency: \`'ar'\` → SAR, others → USD.
- API-additive: existing callers behave as before since they pass no locale and default to \`'en'\`.

## Changes
- \`src/components/marketing/utils.ts\` — \`formatDate\` accepts \`locale\`; new \`formatCurrency\`
- \`src/components/marketing/pricing/lib/utils.ts\` — \`formatDate\` accepts \`locale\`

## Test plan
- [ ] \`formatDate(new Date(), 'ar')\` → \`\"٢٥ أبريل ٢٠٢٦\"\` style
- [ ] \`formatCurrency(100, 'en')\` → \`\"$100.00\"\`
- [ ] \`formatCurrency(100, 'ar')\` → SAR-formatted Arabic numerals
- [ ] Default \`'en'\` behavior unchanged for both functions
- [ ] \`pnpm tsc --noEmit\` no new errors

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)