### PR TITLE
chore(build): strip console.* from production builds

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -4,6 +4,11 @@ const nextConfig: NextConfig = {
   typescript: {
     ignoreBuildErrors: true,
   },
+  compiler: {
+    removeConsole: process.env.NODE_ENV === 'production'
+      ? { exclude: ['error', 'warn'] }
+      : false,
+  },
   images: {
     remotePatterns: [
       {


### PR DESCRIPTION
## Summary
- 69 \`console.*\` calls across 30 files were shipping to prod. Adds \`compiler.removeConsole\` keyed to NODE_ENV.
- Excludes \`error\` and \`warn\` so genuine production issues still emit.
- Dev mode unchanged.

## Changes
- \`next.config.ts\` — add \`compiler.removeConsole\` block

## Test plan
- [ ] \`pnpm build && grep -rE 'console\\.(log\\|debug\\|info)' .next/server | wc -l\` shows significant reduction
- [ ] \`console.error\` and \`console.warn\` still emit in prod
- [ ] \`pnpm dev\` unchanged

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)