### PR TITLE
feat(routing): per-segment loading.tsx for marketing/auth/chatbot/wizard

### DIFF
--- a/src/app/[lang]/(auth)/loading.tsx
+++ b/src/app/[lang]/(auth)/loading.tsx
@@ -1,0 +1,17 @@
+export default function Loading() {
+  return (
+    <div className="flex min-h-screen items-center justify-center px-4">
+      <div className="w-full max-w-sm animate-pulse space-y-6">
+        <div className="space-y-2 text-center">
+          <div className="mx-auto h-8 w-32 bg-muted rounded" />
+          <div className="mx-auto h-4 w-48 bg-muted rounded" />
+        </div>
+        <div className="space-y-3">
+          <div className="h-11 bg-muted rounded" />
+          <div className="h-11 bg-muted rounded" />
+          <div className="h-11 bg-muted rounded" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/[lang]/(marketing)/loading.tsx
+++ b/src/app/[lang]/(marketing)/loading.tsx
@@ -1,0 +1,17 @@
+export default function Loading() {
+  return (
+    <div className="container mx-auto px-4 py-16">
+      <div className="animate-pulse space-y-8">
+        <div className="space-y-3">
+          <div className="h-12 bg-muted rounded w-3/4 mx-auto" />
+          <div className="h-6 bg-muted rounded w-1/2 mx-auto" />
+        </div>
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+          <div className="h-48 bg-muted rounded-xl" />
+          <div className="h-48 bg-muted rounded-xl" />
+          <div className="h-48 bg-muted rounded-xl" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/[lang]/chatbot/loading.tsx
+++ b/src/app/[lang]/chatbot/loading.tsx
@@ -1,0 +1,21 @@
+export default function Loading() {
+  return (
+    <div className="fixed inset-0 flex flex-col bg-background">
+      <div className="flex items-center gap-2 p-4 border-b border-border">
+        <div className="h-5 w-5 bg-muted rounded animate-pulse" />
+        <div className="h-4 w-12 bg-muted rounded animate-pulse" />
+      </div>
+      <div className="flex-1 flex items-center justify-center p-4">
+        <div className="w-full max-w-sm space-y-4 animate-pulse">
+          <div className="h-4 w-2/3 mx-auto bg-muted rounded" />
+          <div className="grid grid-cols-2 gap-2">
+            <div className="h-12 bg-muted rounded" />
+            <div className="h-12 bg-muted rounded" />
+            <div className="h-12 bg-muted rounded" />
+            <div className="h-12 bg-muted rounded" />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/[lang]/wizard/loading.tsx
+++ b/src/app/[lang]/wizard/loading.tsx
@@ -1,0 +1,21 @@
+export default function Loading() {
+  return (
+    <div className="flex min-h-screen items-center justify-center px-4">
+      <div className="grid w-full max-w-3xl grid-cols-1 gap-8 md:grid-cols-2 animate-pulse">
+        <div className="space-y-3">
+          <div className="h-6 w-24 bg-muted rounded" />
+          <div className="h-3 w-40 bg-muted rounded" />
+          <div className="grid grid-cols-3 gap-2 pt-4">
+            <div className="h-9 bg-muted rounded" />
+            <div className="h-9 bg-muted rounded" />
+            <div className="h-9 bg-muted rounded" />
+            <div className="h-9 bg-muted rounded" />
+            <div className="h-9 bg-muted rounded" />
+            <div className="h-9 bg-muted rounded" />
+          </div>
+        </div>
+        <div className="h-72 rounded-xl bg-muted" />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds 4 new \`loading.tsx\` files, one per route group (\`(marketing)\`, \`(auth)\`, \`chatbot\`, \`wizard\`), each with a tailored skeleton matching the segment's layout.
- The existing \`[lang]/loading.tsx\` still acts as the fallback for any segment without its own.

## Changes
- \`src/app/[lang]/(marketing)/loading.tsx\` — heading + 3-card grid
- \`src/app/[lang]/(auth)/loading.tsx\` — narrow centered column with form-row skeletons
- \`src/app/[lang]/chatbot/loading.tsx\` — header bar + 2×2 question-tile grid
- \`src/app/[lang]/wizard/loading.tsx\` — split layout with form-side skeleton

## Test plan
- [ ] Throttled-3G navigation to \`/en/pricing\` shows marketing skeleton
- [ ] \`/ar/login\` shows auth-form skeleton (RTL safe — uses \`mx-auto\` centering)
- [ ] \`/en/chatbot\` shows chatbot skeleton
- [ ] \`/en/wizard\` shows wizard split-layout skeleton

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)