### PR TITLE
perf(chatbot): lazy-load + RSC marketing layout

### DIFF
--- a/src/app/[lang]/(marketing)/layout.tsx
+++ b/src/app/[lang]/(marketing)/layout.tsx
@@ -1,44 +1,28 @@
-'use client';
-
-import { useRef } from 'react';
 import SiteHeader from "@/components/template/site-header/content";
 import SiteFooter from "@/components/template/site-footer/content";
-import { ChatbotContent } from "@/components/chatbot";
+import { LazyChatbot } from "@/components/chatbot/lazy";
 
 export default function SiteLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  const chatbotRef = useRef<{ openChat: () => void }>(null);
-
-  const handleChatClick = () => {
-    // This will be called from the mobile header button
-    console.log('handleChatClick called', { chatbotRef: chatbotRef.current });
-    if (chatbotRef.current?.openChat) {
-      console.log('Opening chat...');
-      chatbotRef.current.openChat();
-    } else {
-      console.warn('Chat ref or openChat method not available');
-    }
-  };
-
   return (
     <div data-slot="site-layout" className="min-h-screen flex flex-col">
-      <SiteHeader onChatClick={handleChatClick} />
-      <main 
+      <SiteHeader />
+      <main
         data-slot="main-content"
         role="main"
         className="flex-1"
         style={{
-          WebkitOverflowScrolling: 'touch',
-          overscrollBehavior: 'none'
+          WebkitOverflowScrolling: "touch",
+          overscrollBehavior: "none",
         }}
       >
         {children}
       </main>
       <SiteFooter />
-      <ChatbotContent ref={chatbotRef} />
+      <LazyChatbot />
     </div>
   );
 }

--- a/src/components/chatbot/lazy.tsx
+++ b/src/components/chatbot/lazy.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import dynamic from "next/dynamic";
+
+const ChatbotContent = dynamic(
+  () => import("./content").then((m) => ({ default: m.ChatbotContent })),
+  {
+    ssr: false,
+    loading: () => null,
+  }
+);
+
+export function LazyChatbot() {
+  return <ChatbotContent />;
+}

--- a/src/components/template/site-header/client.tsx
+++ b/src/components/template/site-header/client.tsx
@@ -7,10 +7,9 @@ import MobileHeader from './mobile-header'
 
 interface SiteHeaderProps {
   isAuthenticated: boolean
-  onChatClick?: () => void
 }
 
-export default function SiteHeaderClient({ isAuthenticated, onChatClick }: SiteHeaderProps) {
+export default function SiteHeaderClient({ isAuthenticated }: SiteHeaderProps) {
   const [isScrolled, setIsScrolled] = useState(false)
 
   useEffect(() => {
@@ -43,7 +42,7 @@ export default function SiteHeaderClient({ isAuthenticated, onChatClick }: SiteH
           <div className="max-w-7xl mx-auto px-6">
             <div className="flex h-12 items-center justify-center gap-4">
               <MainNav />
-              <RightActions isAuthenticated={isAuthenticated} onChatClick={onChatClick} />
+              <RightActions isAuthenticated={isAuthenticated} />
             </div>
           </div>
         </div>

--- a/src/components/template/site-header/content.tsx
+++ b/src/components/template/site-header/content.tsx
@@ -2,12 +2,7 @@ import React from 'react'
 // import { auth } from "@/auth"
 import SiteHeaderClient from './client'
 
-interface SiteHeaderProps {
-  onChatClick?: () => void;
-}
-
-export default function SiteHeader({ onChatClick }: SiteHeaderProps) {
+export default function SiteHeader() {
   // const session = await auth();
-  return <SiteHeaderClient isAuthenticated={false} onChatClick={onChatClick} />
+  return <SiteHeaderClient isAuthenticated={false} />
 }
-  

--- a/src/components/template/site-header/right-actions.tsx
+++ b/src/components/template/site-header/right-actions.tsx
@@ -9,10 +9,9 @@ import { useTranslations } from '@/lib/use-translations'
 
 interface RightActionsProps {
   isAuthenticated: boolean;
-  onChatClick?: () => void;
 }
 
-export function RightActions({ isAuthenticated, onChatClick }: RightActionsProps) {
+export function RightActions({ isAuthenticated }: RightActionsProps) {
   const { t, locale } = useTranslations()
 
   return (


### PR DESCRIPTION
## Summary
- \`(marketing)/layout.tsx\` was a client component purely to hold a chatbot \`useRef\`. Investigation: \`onChatClick\` prop was passed through 4 layers but never actually called. Dead plumbing.
- Converts the layout to RSC, drops the dead prop chain, lazy-loads the chatbot via \`next/dynamic\` in a tiny client island.

## Why this matters
All marketing pages (\`/\`, \`/pricing\`, \`/service\`) now run server-first. Chatbot bundle is no longer in the critical path — fetched only when needed. PERFORMANCE.md claimed \"lazy loading of chat window\" but it wasn't true; this makes it true.

## Changes
- New: \`src/components/chatbot/lazy.tsx\` — \`<LazyChatbot />\` client island wrapping \`next/dynamic(ChatbotContent, { ssr: false })\`
- \`src/app/[lang]/(marketing)/layout.tsx\` — RSC, drops \`useRef\` + handler + \`use client\`
- \`src/components/template/site-header/content.tsx\` — drops \`onChatClick\` prop
- \`src/components/template/site-header/client.tsx\` — drops \`onChatClick\` prop
- \`src/components/template/site-header/right-actions.tsx\` — drops unused \`onChatClick\` prop

## Test plan
- [ ] \`pnpm build\` succeeds; layout is in server bundle
- [ ] Network tab on \`/\` shows chatbot chunk loaded after main content
- [ ] Chatbot button still opens the chat window on \`/\`, \`/pricing\`, \`/service\`
- [ ] LCP improves on marketing routes
- [ ] No \`onChatClick\` references in repo

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)