### PR TITLE
fix(ts): align [lang]/layout params with Next 16 LayoutProps (Class 5)

### DIFF
--- a/src/app/[lang]/layout.tsx
+++ b/src/app/[lang]/layout.tsx
@@ -8,9 +8,15 @@ import { ThemeProvider } from "@/components/atom/theme-provider";
 import { ImageKitProvider } from "@/components/ui/imagekit-provider";
 import { Toaster } from "sonner";
 import { getDictionary } from "@/components/internationalization/dictionaries";
-import { type Locale, localeConfig } from "@/components/internationalization/config";
+import { i18n, type Locale, localeConfig } from "@/components/internationalization/config";
 import { SessionProvider } from "next-auth/react";
 import { auth } from "@/auth";
+
+function resolveLocale(rawLang: string): Locale {
+  return (i18n.locales as readonly string[]).includes(rawLang)
+    ? (rawLang as Locale)
+    : i18n.defaultLocale;
+}
 
 // Configure Rubik font for Arabic
 const rubik = Rubik({
@@ -29,9 +35,10 @@ export const viewport: Viewport = {
 export async function generateMetadata({
   params,
 }: {
-  params: Promise<{ lang: Locale }>;
+  params: Promise<{ lang: string }>;
 }): Promise<Metadata> {
-  const { lang } = await params;
+  const { lang: rawLang } = await params;
+  const lang = resolveLocale(rawLang);
   const dict = await getDictionary(lang);
   const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || 'https://databayt.org';
 
@@ -78,9 +85,10 @@ export default async function LocaleLayout({
   params,
 }: Readonly<{
   children: React.ReactNode;
-  params: Promise<{ lang: Locale }>;
+  params: Promise<{ lang: string }>;
 }>) {
-  const [{ lang }, session] = await Promise.all([params, auth()]);
+  const [{ lang: rawLang }, session] = await Promise.all([params, auth()]);
+  const lang = resolveLocale(rawLang);
   const config = localeConfig[lang];
   const isRTL = config.dir === 'rtl';
 


### PR DESCRIPTION
## Summary
- Class 5 audit error: Next 16's \`LayoutConfig<\"/[lang]\">\` expects \`params: Promise<{ lang: string }>\` but the layout declared \`Promise<{ lang: Locale }>\` (narrowed).
- Loosens to \`string\` + internal validation via \`resolveLocale()\` helper that falls back to \`i18n.defaultLocale\` for unknown segments.

## Stacked on #10
**Base branch**: \`fix/auth-restore-session-provider\`. This PR depends on #10 landing first. When #10 merges to main, this PR's base auto-rebases and merges cleanly. Just review the diff (5 lines added).

## Changes
- \`src/app/[lang]/layout.tsx\` — \`generateMetadata\` and \`LocaleLayout\` params: \`Locale\` → \`string\`; new \`resolveLocale()\` helper.

## Test plan
- [ ] \`pnpm tsc --noEmit\` no longer reports the 2 \`validator.ts\` errors
- [ ] \`/en\` and \`/ar\` still work
- [ ] Invalid locale URL falls back to default (proxy.ts handles redirect; layout-side fallback is defense-in-depth)

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)